### PR TITLE
species -> species_id

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.4")
+setup(version="0.0.5")

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -230,13 +230,13 @@ class ChromosomeLocation(BaseModel):
 
     type: Literal[VRSTypes.CHROMOSOME_LOCATION] = VRSTypes.CHROMOSOME_LOCATION
     id: Optional[CURIE] = Field(alias='_id')
-    species: CURIE
+    species_id: CURIE
     chr: StrictStr
     interval: CytobandInterval
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_species_id_val = \
-        validator('species', allow_reuse=True)(return_value)
+        validator('species_id', allow_reuse=True)(return_value)
 
 
 class SequenceLocation(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def chromosome_location(cytoband_interval):
     return ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species="taxonomy:9606"
+        species_id="taxonomy:9606"
     )
 
 

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -188,18 +188,18 @@ def test_chromosome_location(chromosome_location, cytoband_interval):
     assert ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species="taxonomy:9606",
+        species_id="taxonomy:9606",
         type="ChromosomeLocation"
     )
 
     invalid_params = [
         {"chr": "1",
          "interval": {"start": "q13.32!", "end": "q13.32"},
-         "species": "taxonomy:9606"
+         "species_id": "taxonomy:9606"
          },
         {"chr": "1",
          "interval": {"start": "q13.32", "end": "q13.32"},
-         "species_id": "taxonomy:9606"
+         "species": "taxonomy:9606"
          }
     ]
 

--- a/tests/test_vrsatile_models.py
+++ b/tests/test_vrsatile_models.py
@@ -137,7 +137,7 @@ def test_location_descriptor(location_descriptor, sequence_location, gene):
     assert location_descriptor.location.chr == "19"
     assert location_descriptor.location.interval.start == "q13.32"
     assert location_descriptor.location.interval.end == "q13.32"
-    assert location_descriptor.location.species == "taxonomy:9606"
+    assert location_descriptor.location.species_id == "taxonomy:9606"
     assert location_descriptor.location.type == "ChromosomeLocation"
 
     ld = LocationDescriptor(id="vod:id2", location_id="gene:b",


### PR DESCRIPTION
Fix bug in VRS docs (`species` is actually `species_id`)