### PR TITLE
Issue 18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.3")
+setup(version="0.0.4")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.6")
+setup(version="0.0.7")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.4")
+setup(version="0.0.5")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.5")
+setup(version="0.0.6")

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -303,6 +303,15 @@ class Feature(BaseModel):
 
     __root__: Gene
 
+    class Config:
+        """Configure Pydantic attributes."""
+
+        @staticmethod
+        def schema_extra(schema, model):
+            """Ensure JSON schema output matches original VRS model."""
+            del schema["$ref"]
+            schema["anyOf"] = [{"$ref": "#/components/schema/Gene"}]
+
 
 class Location(BaseModel):
     """A contiguous segment of a biological sequence."""
@@ -387,6 +396,15 @@ class SystemicVariation(BaseModel):
     """
 
     __root__: CopyNumber
+
+    class Config:
+        """Configure Pydantic attributes."""
+
+        @staticmethod
+        def schema_extra(schema, model):
+            """Ensure JSON schema output matches original VRS model."""
+            del schema["$ref"]
+            schema["anyOf"] = [{"$ref": "#/components/schema/CopyNumber"}]
 
 
 class Variation(BaseModel):

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -230,13 +230,13 @@ class ChromosomeLocation(BaseModel):
 
     type: Literal[VRSTypes.CHROMOSOME_LOCATION] = VRSTypes.CHROMOSOME_LOCATION
     id: Optional[CURIE] = Field(alias='_id')
-    species: CURIE
+    species_id: CURIE
     chr: StrictStr
     interval: CytobandInterval
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_species_id_val = \
-        validator('species', allow_reuse=True)(return_value)
+        validator('species_id', allow_reuse=True)(return_value)
 
 
 class SequenceLocation(BaseModel):

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -143,6 +143,7 @@ class Text(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.TEXT] = VRSTypes.TEXT
@@ -227,6 +228,7 @@ class ChromosomeLocation(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     type: Literal[VRSTypes.CHROMOSOME_LOCATION] = VRSTypes.CHROMOSOME_LOCATION
     id: Optional[CURIE] = Field(alias='_id')
@@ -246,11 +248,12 @@ class SequenceLocation(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.SEQUENCE_LOCATION] = VRSTypes.SEQUENCE_LOCATION
     sequence_id: CURIE
-    interval: Union[SequenceInterval]
+    interval: SequenceInterval
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_sequence_id_val = \
@@ -324,11 +327,12 @@ class Allele(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.ALLELE] = VRSTypes.ALLELE
     location: Union[CURIE, Location]
-    state: Union[SequenceExpression]
+    state: SequenceExpression
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_loc_val = validator('location', allow_reuse=True)(return_value)
@@ -342,6 +346,7 @@ class Haplotype(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.HAPLOTYPE] = VRSTypes.HAPLOTYPE
@@ -365,6 +370,7 @@ class CopyNumber(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.COPY_NUMBER] = VRSTypes.COPY_NUMBER
@@ -405,6 +411,7 @@ class VariationSet(BaseModel):
         """Class configs."""
 
         extra = Extra.forbid
+        allow_population_by_field_name = True
 
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.VARIATION_SET] = VRSTypes.VARIATION_SET

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -13,8 +13,6 @@ class VRSTypes(str, Enum):
     NUMBER = "Number"
     INDEFINITE_RANGE = "IndefiniteRange"
     DEFINITE_RANGE = "DefiniteRange"
-    SEQUENCE_STATE = "SequenceState"
-    SIMPLE_INTERVAL = "SimpleInterval"
     TEXT = "Text"
     SEQUENCE_INTERVAL = "SequenceInterval"
     CYTOBAND_INTERVAL = "CytobandInterval"
@@ -136,39 +134,6 @@ class HumanCytoband(BaseModel):
         = Field(..., example="q22.3")  # noqa: F722
 
 
-class SequenceState(BaseModel):
-    """DEPRECATED: An assertion of the state of a sequence, typically at a
-    Sequence Location within an Allele. This class is deprecated. Use
-    LiteralSequenceExpression instead.
-    """
-
-    class Config:
-        """Class configs."""
-
-        extra = Extra.forbid
-
-    type: Literal[VRSTypes.SEQUENCE_STATE] = VRSTypes.SEQUENCE_STATE
-    sequence: Sequence
-
-    _get_id_val = validator('sequence', allow_reuse=True)(return_value)
-
-
-class SimpleInterval(BaseModel):
-    """DEPRECATED: A SimpleInterval represents a span of sequence.
-    Positions are always represented by contiguous spans using interbase
-    coordinates. This class is deprecated. Use SequenceInterval instead.
-    """
-
-    class Config:
-        """Class configs."""
-
-        extra = Extra.forbid
-
-    type: Literal[VRSTypes.SIMPLE_INTERVAL] = VRSTypes.SIMPLE_INTERVAL
-    start: StrictInt
-    end: StrictInt
-
-
 class Text(BaseModel):
     """An textual representation of variation intended to capture variation
     descriptions that cannot be parsed, but still treated as variation.
@@ -265,13 +230,13 @@ class ChromosomeLocation(BaseModel):
 
     type: Literal[VRSTypes.CHROMOSOME_LOCATION] = VRSTypes.CHROMOSOME_LOCATION
     id: Optional[CURIE] = Field(alias='_id')
-    species_id: CURIE
+    species: CURIE
     chr: StrictStr
     interval: CytobandInterval
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_species_id_val = \
-        validator('species_id', allow_reuse=True)(return_value)
+        validator('species', allow_reuse=True)(return_value)
 
 
 class SequenceLocation(BaseModel):
@@ -285,7 +250,7 @@ class SequenceLocation(BaseModel):
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.SEQUENCE_LOCATION] = VRSTypes.SEQUENCE_LOCATION
     sequence_id: CURIE
-    interval: Union[SequenceInterval, SimpleInterval]
+    interval: Union[SequenceInterval]
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_sequence_id_val = \
@@ -363,7 +328,7 @@ class Allele(BaseModel):
     id: Optional[CURIE] = Field(alias='_id')
     type: Literal[VRSTypes.ALLELE] = VRSTypes.ALLELE
     location: Union[CURIE, Location]
-    state: Union[SequenceState, SequenceExpression]
+    state: Union[SequenceExpression]
 
     _get_id_val = validator('id', allow_reuse=True)(return_value)
     _get_loc_val = validator('location', allow_reuse=True)(return_value)

--- a/src/ga4gh/vrsatile/pydantic/vrsatile_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrsatile_models.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import List, Optional, Union, Any, Literal
 from pydantic import BaseModel, Extra, StrictInt, StrictStr, \
     root_validator, validator
-from ga4gh.vrsatile.pydantic.vrs_model import CURIE, Allele, Haplotype, \
+from ga4gh.vrsatile.pydantic.vrs_models import CURIE, Allele, Haplotype, \
     CopyNumber, Text, VariationSet, SequenceLocation, ChromosomeLocation,\
     Sequence, Gene
 from ga4gh.vrsatile.pydantic import return_value
@@ -134,7 +134,6 @@ class LocationDescriptor(ValueObjectDescriptor):
         VODClassName.LOCATION_DESCRIPTOR
     location_id: Optional[CURIE]
     location: Optional[Union[SequenceLocation, ChromosomeLocation]]
-    sequence_descriptor: Optional[SequenceDescriptor]
 
     @root_validator(pre=True)
     def check_location_or_location_id_present(cls, values):
@@ -213,8 +212,6 @@ class VariationDescriptor(ValueObjectDescriptor):
     vcf_record: Optional[VCFRecord]
     gene_context: Optional[Union[CURIE, GeneDescriptor]]
     vrs_ref_allele_seq: Optional[Sequence]
-    location_descriptor: Optional[LocationDescriptor]
-    sequence_descriptor: Optional[SequenceDescriptor]
     allelic_state: Optional[CURIE]
 
     _get_variation_id_val = \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 """Module for pytest config tools."""
 import pytest
-from ga4gh.vrsatile.pydantic.vrs_model import SequenceInterval, \
+from ga4gh.vrsatile.pydantic.vrs_models import SequenceInterval, \
     CytobandInterval, SequenceLocation, DerivedSequenceExpression, Number, \
     IndefiniteRange, DefiniteRange, Allele, LiteralSequenceExpression, Gene, \
     ChromosomeLocation
-from ga4gh.vrsatile.pydantic.vrsatile_model import Extension, Expression, \
+from ga4gh.vrsatile.pydantic.vrsatile_models import Extension, Expression, \
     SequenceDescriptor, LocationDescriptor, GeneDescriptor, VCFRecord
 
 
@@ -49,7 +49,7 @@ def chromosome_location(cytoband_interval):
     return ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species_id="taxonomy:9606"
+        species="taxonomy:9606"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def chromosome_location(cytoband_interval):
     return ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species="taxonomy:9606"
+        species_id="taxonomy:9606"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,3 +123,37 @@ def vcf_record():
     """Create test fixture for VCF Record."""
     return VCFRecord(genome_assembly="grch38", chrom="9", pos=123,
                      ref="A", alt="C")
+
+
+@pytest.fixture(scope="session")
+def braf_v600e_variation():
+    """Create test fixture for BRAF V600E variation"""
+    return {
+        "id": "ga4gh:VA.8JkgnqIgYqufNl-OV_hpRG_aWF9UFQCE",
+        "type": "Allele",
+        "location": {
+            "id": "ga4gh:VSL.AqrQ-EkAvTrXOFn70_8i3dXF5shBBZ5i",
+            "type": "SequenceLocation",
+            "sequence_id": "ga4gh:SQ.WaAJ_cXXn9YpMNfhcq9lnzIvaB9ALawo",
+            "interval": {
+                "type": "SequenceInterval",
+                "start": {"type": "Number", "value": 639},
+                "end": {"type": "Number", "value": 640}
+            }
+        },
+        "state": {"type": "LiteralSequenceExpression", "sequence": "E"}
+    }
+
+
+@pytest.fixture(scope="session")
+def braf_v600e_vd(braf_v600e_variation):
+    """Create test fixture for BRAF V600E variation descriptor"""
+    return {
+        "id": "normalize.variation:braf%20v600e",
+        "type": "VariationDescriptor",
+        "variation_id": "ga4gh:VA.8JkgnqIgYqufNl-OV_hpRG_aWF9UFQCE",
+        "variation": braf_v600e_variation,
+        "molecule_context": "protein",
+        "structural_type": "SO:0001606",
+        "vrs_ref_allele_seq": "V"
+    }

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -88,10 +88,15 @@ def test_text():
     assert t_dict['_id'] == 'ga4gh:id'
     assert 'id' not in t_dict.keys()
 
+    params = {"definition": definition, "id": "ga4gh:id"}
+    assert Text(**params)
+
+    params = {"definition": definition, "_id": "ga4gh:id"}
+    assert Text(**params)
+
     invalid_params = [
         {"definition": definition, "type": "Definition"},
-        {"definition": definition, "_id": "id"},
-        {"definition": definition, "id": "ga4gh:id"}
+        {"definition": definition, "_id": "id"}
     ]
 
     for invalid_param in invalid_params:
@@ -222,6 +227,20 @@ def test_sequence_location(sequence_location, sequence_interval):
     assert s.sequence_id == "refseq:NC_000007.13"
     assert sequence_location.type == "SequenceLocation"
 
+    params = {
+        "id": "sequence:id",
+        "sequence_id": "refseq:NC_000007.13",
+        "interval": sequence_interval
+    }
+    assert SequenceLocation(**params)
+
+    params = {
+        "_id": "sequence:id",
+        "sequence_id": "refseq:NC_000007.13",
+        "interval": sequence_interval
+    }
+    assert SequenceLocation(**params)
+
     invalid_params = [
         {
             "_id": "sequence",
@@ -233,11 +252,6 @@ def test_sequence_location(sequence_location, sequence_interval):
             "sequence_id": "NC_000007.13",
             "interval": sequence_interval,
             "type": "ChromosomeLocation"
-        },
-        {
-            "id": "sequence:id",
-            "sequence_id": "refseq:NC_000007.13",
-            "interval": sequence_interval
         },
         {
             "id": "sequence:id",

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -188,18 +188,18 @@ def test_chromosome_location(chromosome_location, cytoband_interval):
     assert ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species="taxonomy:9606",
+        species_id="taxonomy:9606",
         type="ChromosomeLocation"
     )
 
     invalid_params = [
         {"chr": "1",
          "interval": {"start": "q13.32!", "end": "q13.32"},
-         "species": "taxonomy:9606"
+         "species_id": "taxonomy:9606"
          },
         {"chr": "1",
          "interval": {"start": "q13.32", "end": "q13.32"},
-         "species_id": "taxonomy:9606"
+         "species": "taxonomy:9606"
          }
     ]
 

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -6,7 +6,7 @@ from ga4gh.vrsatile.pydantic.vrs_models import Number, Comparator, \
     SequenceInterval, CytobandInterval, DerivedSequenceExpression, \
     LiteralSequenceExpression, RepeatedSequenceExpression, Gene, \
     SequenceLocation, VariationSet, Haplotype, \
-    CopyNumber, Allele, ChromosomeLocation
+    CopyNumber, Allele, ChromosomeLocation, Feature, SystemicVariation
 
 
 def test_number(number):
@@ -445,3 +445,26 @@ def test_variation_set(allele, sequence_location):
         with pytest.raises(pydantic.error_wrappers.ValidationError):
 
             VariationSet(**invalid_param)
+
+
+def test_feature(gene):
+    """Test Feature class."""
+    schema = Feature.schema()
+    assert schema["title"] == "Feature"
+    assert schema["description"] == "A named entity that can be mapped to a Location. Genes, protein domains,\nexons, and chromosomes are some examples of common biological entities\nthat may be Features."  # noqa: E501
+    assert schema
+    assert schema["anyOf"][0]["$ref"] == "#/components/schema/Gene"
+
+    assert Feature(__root__=gene)
+
+
+def test_systemic_variation(gene, number):
+    """Test SystemicVariation class."""
+    schema = SystemicVariation.schema()
+    assert schema["title"] == "SystemicVariation"
+    assert schema["description"] == "A Variation of multiple molecules in the context of a system,\ne.g. a genome, sample, or homologous chromosomes."  # noqa: E501
+    assert schema
+    assert schema["anyOf"][0]["$ref"] == "#/components/schema/CopyNumber"
+
+    c = CopyNumber(subject=gene, copies=number)
+    assert SystemicVariation(__root__=c)

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -1,8 +1,8 @@
 """Module for testing the VRS model."""
 import pydantic
 import pytest
-from ga4gh.vrsatile.pydantic.vrs_model import Number, Comparator, \
-    IndefiniteRange, DefiniteRange, SequenceState, SimpleInterval, Text, \
+from ga4gh.vrsatile.pydantic.vrs_models import Number, Comparator, \
+    IndefiniteRange, DefiniteRange, Text, \
     SequenceInterval, CytobandInterval, DerivedSequenceExpression, \
     LiteralSequenceExpression, RepeatedSequenceExpression, Gene, \
     SequenceLocation, VariationSet, Haplotype, \
@@ -69,45 +69,6 @@ def test_definite_range(definite_range):
     for invalid_param in invalid_params:
         with pytest.raises(pydantic.error_wrappers.ValidationError):
             DefiniteRange(**invalid_param)
-
-
-def test_sequence_state():
-    """Test that Sequence State model works correctly."""
-    s = SequenceState(sequence="T")
-    assert s.sequence == 'T'
-    assert s.type == "SequenceState"
-
-    assert SequenceState(sequence="T", type="SequenceState")
-
-    invalid_params = [
-        {"sequence": "t"},
-        {"sequence": "T", "type": "Sequence"},
-        {"sequence": "hello,world"}
-    ]
-
-    for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
-            SequenceState(**invalid_param)
-
-
-def test_simple_interval():
-    """Test that Simple Interval model works correctly."""
-    s = SimpleInterval(start=2, end=2)
-    assert s.start == 2
-    assert s.end == 2
-    assert s.type == "SimpleInterval"
-
-    assert SimpleInterval(start=2, end=2, type="SimpleInterval")
-
-    invalid_params = [
-        {"start": 2.0, "end": 2},
-        {"start": 2, "end": 2, "type": "CytobandInterval"},
-        {"start": 2, "end": '2'}
-    ]
-
-    for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
-            SimpleInterval(**invalid_param)
 
 
 def test_text():
@@ -227,13 +188,17 @@ def test_chromosome_location(chromosome_location, cytoband_interval):
     assert ChromosomeLocation(
         chr="19",
         interval=cytoband_interval,
-        species_id="taxonomy:9606",
+        species="taxonomy:9606",
         type="ChromosomeLocation"
     )
 
     invalid_params = [
         {"chr": "1",
          "interval": {"start": "q13.32!", "end": "q13.32"},
+         "species": "taxonomy:9606"
+         },
+        {"chr": "1",
+         "interval": {"start": "q13.32", "end": "q13.32"},
          "species_id": "taxonomy:9606"
          }
     ]
@@ -273,6 +238,15 @@ def test_sequence_location(sequence_location, sequence_interval):
             "id": "sequence:id",
             "sequence_id": "refseq:NC_000007.13",
             "interval": sequence_interval
+        },
+        {
+            "id": "sequence:id",
+            "sequence_id": "test:1",
+            "interval": {
+                "type": "SimpleInterval",
+                "start": 1,
+                "end": 2
+            }
         }
     ]
 

--- a/tests/test_vrsatile_models.py
+++ b/tests/test_vrsatile_models.py
@@ -214,12 +214,17 @@ def test_vcf_record(vcf_record):
 
 
 def test_variation_descriptor(allele, gene_descriptor, vcf_record, expression,
-                              extension):
+                              extension, braf_v600e_vd):
     """Test that Variation Descriptor model works correctly."""
     vd = VariationDescriptor(id="var:id", variation_id="variation:id")
     assert vd.id == "var:id"
     assert vd.variation_id == "variation:id"
     assert vd.type == "VariationDescriptor"
+
+    vd = VariationDescriptor(**braf_v600e_vd)
+    assert vd.variation.type == "Allele"
+    assert vd.variation.location.type == "SequenceLocation"
+    assert vd.variation.location.interval.type == "SequenceInterval"
 
     vd = VariationDescriptor(id="var:id", variation=allele,
                              type="VariationDescriptor",

--- a/tests/test_vrsatile_models.py
+++ b/tests/test_vrsatile_models.py
@@ -137,7 +137,7 @@ def test_location_descriptor(location_descriptor, sequence_location, gene):
     assert location_descriptor.location.chr == "19"
     assert location_descriptor.location.interval.start == "q13.32"
     assert location_descriptor.location.interval.end == "q13.32"
-    assert location_descriptor.location.species == "taxonomy:9606"
+    assert location_descriptor.location.species_id == "taxonomy:9606"
     assert location_descriptor.location.type == "ChromosomeLocation"
 
     ld = LocationDescriptor(id="vod:id2", location_id="gene:b",

--- a/tests/test_vrsatile_models.py
+++ b/tests/test_vrsatile_models.py
@@ -1,7 +1,7 @@
 """Module for testing the VRSATILE model."""
 import pydantic
 import pytest
-from ga4gh.vrsatile.pydantic.vrsatile_model import  \
+from ga4gh.vrsatile.pydantic.vrsatile_models import  \
     MoleculeContext, Extension, Expression, ValueObjectDescriptor, \
     SequenceDescriptor, LocationDescriptor, GeneDescriptor, \
     VariationDescriptor, VCFRecord
@@ -137,7 +137,7 @@ def test_location_descriptor(location_descriptor, sequence_location, gene):
     assert location_descriptor.location.chr == "19"
     assert location_descriptor.location.interval.start == "q13.32"
     assert location_descriptor.location.interval.end == "q13.32"
-    assert location_descriptor.location.species_id == "taxonomy:9606"
+    assert location_descriptor.location.species == "taxonomy:9606"
     assert location_descriptor.location.type == "ChromosomeLocation"
 
     ld = LocationDescriptor(id="vod:id2", location_id="gene:b",


### PR DESCRIPTION
Fixes #18 

You can check that it resolves the openapi issue

1. In another library (eg variation) manually install w/ `pip install -e path/to/vrs/pydantic`
2. start the library server `uvicorn variation.main:app --reload`
3. get the openapi schema `curl -O http://localhost:8000/variation/openapi.json`
4. install the validation tool `pip install openapi3`
5. run it `python3 -m openapi3 openapi.json`

^ This gave me the same warnings described by Brian when using the staging branch version, but came out ok using this branch:

```
(variant-normalization) ~/code/variant-normalization (staging) % python3 -m openapi3 openapi.json
OK
```