### PR TITLE
Add an 's'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 """Module for package and distribution"""
 from setuptools import setup
 
-setup(version="0.0.7")
+setup(version="0.0.8")

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -310,7 +310,7 @@ class Feature(BaseModel):
         def schema_extra(schema, model):
             """Ensure JSON schema output matches original VRS model."""
             del schema["$ref"]
-            schema["anyOf"] = [{"$ref": "#/components/schema/Gene"}]
+            schema["anyOf"] = [{"$ref": "#/components/schemas/Gene"}]
 
 
 class Location(BaseModel):
@@ -404,7 +404,7 @@ class SystemicVariation(BaseModel):
         def schema_extra(schema, model):
             """Ensure JSON schema output matches original VRS model."""
             del schema["$ref"]
-            schema["anyOf"] = [{"$ref": "#/components/schema/CopyNumber"}]
+            schema["anyOf"] = [{"$ref": "#/components/schemas/CopyNumber"}]
 
 
 class Variation(BaseModel):

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -453,7 +453,7 @@ def test_feature(gene):
     assert schema["title"] == "Feature"
     assert schema["description"] == "A named entity that can be mapped to a Location. Genes, protein domains,\nexons, and chromosomes are some examples of common biological entities\nthat may be Features."  # noqa: E501
     assert schema
-    assert schema["anyOf"][0]["$ref"] == "#/components/schema/Gene"
+    assert schema["anyOf"][0]["$ref"] == "#/components/schemas/Gene"
 
     assert Feature(__root__=gene)
 
@@ -464,7 +464,7 @@ def test_systemic_variation(gene, number):
     assert schema["title"] == "SystemicVariation"
     assert schema["description"] == "A Variation of multiple molecules in the context of a system,\ne.g. a genome, sample, or homologous chromosomes."  # noqa: E501
     assert schema
-    assert schema["anyOf"][0]["$ref"] == "#/components/schema/CopyNumber"
+    assert schema["anyOf"][0]["$ref"] == "#/components/schemas/CopyNumber"
 
     c = CopyNumber(subject=gene, copies=number)
     assert SystemicVariation(__root__=c)


### PR DESCRIPTION
Trying again because the diff was weird before

The python openapi verification tool doesn't care either way, but SwaggerUI will show a red warning window and this appears to fix it