### PR TITLE
feat: apply vrs 1.3 cnv changes to metaschema-update

### DIFF
--- a/src/ga4gh/vrsatile/pydantic/version.py
+++ b/src/ga4gh/vrsatile/pydantic/version.py
@@ -1,2 +1,2 @@
 """ga4gh.vrsatile.pydantic version"""
-__version__ = "0.1.0-dev7"
+__version__ = "0.1.0-dev8"

--- a/src/ga4gh/vrsatile/pydantic/vrs_models.py
+++ b/src/ga4gh/vrsatile/pydantic/vrs_models.py
@@ -43,14 +43,14 @@ class Comparator(str, Enum):
 class CopyChange(str, Enum):
     """The copy change (https://www.ebi.ac.uk/efo/)"""
 
-    COMPLETE_GENOMIC_LOSS = "EFO:0030069"
-    HIGH_LEVEL_LOSS = "EFO:0020073"
-    LOW_LEVEL_LOSS = "EFO:0030068"
-    LOSS = "EFO:0030067"
-    REGIONAL_BASE_PLOIDY = "EFO:0030064"
-    GAIN = "EFO:0030070"
-    LOW_LEVEL_GAIN = "EFO:0030071"
-    HIGH_LEVEL_GAIN = "EFO:0030072"
+    COMPLETE_GENOMIC_LOSS = "efo:0030069"
+    HIGH_LEVEL_LOSS = "efo:0020073"
+    LOW_LEVEL_LOSS = "efo:0030068"
+    LOSS = "efo:0030067"
+    REGIONAL_BASE_PLOIDY = "efo:0030064"
+    GAIN = "efo:0030070"
+    LOW_LEVEL_GAIN = "efo:0030071"
+    HIGH_LEVEL_GAIN = "efo:0030072"
 
 
 # =============================================================================

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -386,21 +386,21 @@ def test_copy_number_count(number, definite_range, indefinite_range, gene, allel
 
 def test_copy_number_change(number, sequence_location, gene, allele):
     """Test that Copy Number Change model works correctly."""
-    c = CopyNumberChange(subject=gene, copy_change="EFO:0030069")
+    c = CopyNumberChange(subject=gene, copy_change="efo:0030069")
     assert c.subject.id == "ncbigene:348"
     assert c.subject.type == "Gene"
-    assert c.copy_change == "EFO:0030069"
+    assert c.copy_change == "efo:0030069"
     assert c.type == "CopyNumberChange"
 
-    c = CopyNumberChange(subject=sequence_location, copy_change="EFO:0030071")
+    c = CopyNumberChange(subject=sequence_location, copy_change="efo:0030071")
     assert c.subject.type == "SequenceLocation"
-    assert c.copy_change == "EFO:0030071"
+    assert c.copy_change == "efo:0030071"
 
     invalid_params = [
         {"subject": number, "copies": number},
-        {"ID": "ga4gh:id", "subject": gene, "copy_change": "EFO:0030069"},
+        {"ID": "ga4gh:id", "subject": gene, "copy_change": "efo:0030069"},
         {"subject": allele},
-        {"subject": "fake:curie", "copy_change": "EFO:0030071", "extra": 0},
+        {"subject": "fake:curie", "copy_change": "efo:0030071", "extra": 0},
         {"subject": "fake:curie", "copy_change": "low-level"},
         {"subject": allele, "copy_change": "partial loss"},
     ]


### PR DESCRIPTION
Close #62 

Notes:
- Removes Feature (should not have been in metaschema-update)
- AbsoluteCopyNumber --> CopyNumberCount
- RelativeCopyNumber --> CopyNumberChange
- Will do a cleanup similar to what was done in #59 afterwards 