### PR TITLE
build!: upgrade to pydantic v2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pydantic = "~=1.10.9"
+pydantic = "~=2.4.2"
 
 [dev-packages]
 "ga4gh.vrsatile.pydantic" = {editable = true, path = "."}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The ga4gh/vrsatile/pydantic repo depends on VRS and VRSATILE models, and therefo
 
 | ga4gh.vrsatile.pydantic branch | ga4gh.vrsatile.pydantic version | VRS version | VRSATILE version |
 | ---- | --- | --- | --- |
-| main | 0.0.X | [1.X.X](https://github.com/ga4gh/vrs) | [main](https://github.com/ga4gh/vrsatile/tree/main) |
+| main | 0.2.X | [1.X.X](https://github.com/ga4gh/vrs) | [main](https://github.com/ga4gh/vrsatile/tree/main) |
 | metaschema-update | 0.1.X | [metaschema-update](https://github.com/ga4gh/vrs/tree/metaschema-update) | [metaschema-update](https://github.com/ga4gh/vrsatile/tree/metaschema-update) |
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = False
 package_dir =
     = src
 install_requires =
-    pydantic ~= 1.10.9
+    pydantic ~= 2.4.2
 tests_require =
     pytest
     pytest-cov

--- a/src/ga4gh/vrsatile/pydantic/__init__.py
+++ b/src/ga4gh/vrsatile/pydantic/__init__.py
@@ -2,26 +2,24 @@
 import logging
 from abc import ABC
 
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, model_validator, ConfigDict
 
 
 logger = logging.getLogger("vrsatile-pydantic")
 
 
-class BaseModelForbidExtra(BaseModel, ABC):
+class BaseModelForbidExtra(BaseModel, ABC, extra="forbid"):
     """Base Pydantic model class with extra values forbidden."""
 
-    class Config:
-        """Class configs."""
-
-        extra = Extra.forbid
-        allow_population_by_field_name = True
+    model_config = ConfigDict(
+        populate_by_name=True
+    )
 
 
 class BaseModelDeprecated(BaseModel, ABC):
     """Base Pydantic model class to use for deprecated classes."""
 
-    @root_validator(pre=True)
+    @model_validator(mode="after")
     def log_deprecated_warning(cls, values):
         """Log warning that object class is deprecated."""
         if hasattr(cls, "_replace_with"):
@@ -46,13 +44,13 @@ def return_value(cls, v):
                 for item in v:
                     while True:
                         try:
-                            item = item.__root__
+                            item = item.root
                         except AttributeError:
                             break
                     tmp.append(item)
                 v = tmp
             else:
-                v = v.__root__
+                v = v.root
         except AttributeError:
             pass
     return v

--- a/src/ga4gh/vrsatile/pydantic/version.py
+++ b/src/ga4gh/vrsatile/pydantic/version.py
@@ -1,2 +1,2 @@
 """ga4gh.vrsatile.pydantic version"""
-__version__ = "0.0.13"
+__version__ = "0.2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,10 +151,10 @@ def vcf_record():
 def braf_v600e_variation():
     """Create test fixture for BRAF V600E variation"""
     return {
-        "id": "ga4gh:VA.8JkgnqIgYqufNl-OV_hpRG_aWF9UFQCE",
+        "_id": "ga4gh:VA.8JkgnqIgYqufNl-OV_hpRG_aWF9UFQCE",
         "type": "Allele",
         "location": {
-            "id": "ga4gh:VSL.AqrQ-EkAvTrXOFn70_8i3dXF5shBBZ5i",
+            "_id": "ga4gh:VSL.AqrQ-EkAvTrXOFn70_8i3dXF5shBBZ5i",
             "type": "SequenceLocation",
             "sequence_id": "ga4gh:SQ.WaAJ_cXXn9YpMNfhcq9lnzIvaB9ALawo",
             "interval": {

--- a/tests/test_vrs_models.py
+++ b/tests/test_vrs_models.py
@@ -25,7 +25,7 @@ def test_number(number):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Number(**invalid_param)
 
 
@@ -54,7 +54,7 @@ def test_indefinite_range(indefinite_range):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             IndefiniteRange(**invalid_param)
 
 
@@ -79,7 +79,7 @@ def test_definite_range(definite_range):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             DefiniteRange(**invalid_param)
 
 
@@ -96,12 +96,9 @@ def test_text():
     assert t.definition == definition
     assert t.type == "Text"
     assert t.id == "ga4gh:id"
-    t_dict = t.dict(by_alias=True)
+    t_dict = t.model_dump(by_alias=True)
     assert t_dict['_id'] == 'ga4gh:id'
     assert 'id' not in t_dict.keys()
-
-    params = {"definition": definition, "id": "ga4gh:id"}
-    assert Text(**params)
 
     params = {"definition": definition, "_id": "ga4gh:id"}
     assert Text(**params)
@@ -112,7 +109,7 @@ def test_text():
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Text(**invalid_param)
 
 
@@ -158,7 +155,7 @@ def test_sequence_interval(sequence_interval):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             SequenceInterval(**invalid_param)
 
 
@@ -178,7 +175,7 @@ def test_cytoband_interval(cytoband_interval):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             CytobandInterval(**invalid_param)
 
 
@@ -198,7 +195,7 @@ def test_literal_sequence_expression():
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             LiteralSequenceExpression(**invalid_param)
 
 
@@ -215,7 +212,7 @@ def test_composed_sequence_expression(derived_sequence_expression, number):
         ]
     )
 
-    with pytest.raises(pydantic.error_wrappers.ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         ComposedSequenceExpression(components=[
             LiteralSequenceExpression(sequence="ACGT",
                                       type="LiteralSequenceExpression"),
@@ -237,7 +234,7 @@ def test_gene():
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Gene(**invalid_param)
 
 
@@ -276,7 +273,7 @@ def test_chromosome_location(chromosome_location, cytoband_interval):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             ChromosomeLocation(**invalid_param)
 
 
@@ -293,13 +290,6 @@ def test_sequence_location(sequence_location, sequence_interval):
     assert s.id == "sequence:id"
     assert s.sequence_id == "refseq:NC_000007.13"
     assert sequence_location.type == "SequenceLocation"
-
-    params = {
-        "id": "sequence:id",
-        "sequence_id": "refseq:NC_000007.13",
-        "interval": sequence_interval
-    }
-    assert SequenceLocation(**params)
 
     params = {
         "_id": "sequence:id",
@@ -323,7 +313,7 @@ def test_sequence_location(sequence_location, sequence_interval):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             SequenceLocation(**invalid_param)
 
 
@@ -352,7 +342,7 @@ def test_derived_sequence_expression(sequence_location,
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             DerivedSequenceExpression(**invalid_param)
 
 
@@ -404,7 +394,7 @@ def test_repeated_sequence_expression(derived_sequence_expression, number,
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             RepeatedSequenceExpression(**invalid_param)
 
 
@@ -426,7 +416,7 @@ def test_allele(allele, sequence_location, derived_sequence_expression):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Allele(**invalid_param)
 
 
@@ -447,7 +437,7 @@ def test_haplotype(allele):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Haplotype(**invalid_param)
 
 
@@ -480,7 +470,7 @@ def test_copy_number_count(number, definite_range, indefinite_range, gene, allel
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             CopyNumberCount(**invalid_param)
 
 
@@ -505,7 +495,7 @@ def test_copy_number_change(number, sequence_location, gene, allele):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             CopyNumberChange(**invalid_param)
 
 
@@ -533,31 +523,25 @@ def test_variation_set(allele, sequence_location):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             VariationSet(**invalid_param)
 
 
 def test_feature(gene):
     """Test Feature class."""
-    schema = Feature.schema()
-    assert schema["title"] == "Feature"
-    assert schema["description"] == "A named entity that can be mapped to a Location. Genes, protein domains, exons, and chromosomes are some examples of common biological entities that may be Features."  # noqa: E501
-    assert schema
-    assert schema["anyOf"][0]["$ref"] == "#/components/schemas/Gene"
-
-    assert Feature(__root__=gene)
+    assert Feature(root=gene)
 
 
 def test_systemic_variation(gene, number):
     """Test SystemicVariation class."""
     c = CopyNumberCount(subject=gene, copies=number)
-    assert SystemicVariation(__root__=c)
+    assert SystemicVariation(root=c)
 
 
 def test_deprecated_objects(caplog, deprecated_allele):
     """Test that deprecated objects work and log appropriately."""
-    seqstate_deprecated_msg = "SequenceState is deprecated. Use LiteralSequenceExpression instead."  # noqa: E501
-    simpleint_deprecated_msg = "SimpleInterval is deprecated. Use SequenceInterval instead."  # noqa: E501
+    seqstate_deprecated_msg = "SequenceState is deprecated. Use default='LiteralSequenceExpression' instead."  # noqa: E501
+    simpleint_deprecated_msg = "SimpleInterval is deprecated. Use default='SequenceInterval' instead."  # noqa: E501
     seqstate = SequenceState(**deprecated_allele["state"])
     assert seqstate.type == "SequenceState"
     assert seqstate.sequence == "T"
@@ -569,7 +553,7 @@ def test_deprecated_objects(caplog, deprecated_allele):
         {"sequence": "hello,world"}
     ]
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             SequenceState(**invalid_param)
 
     simpleint = SimpleInterval(**deprecated_allele["location"]["interval"])
@@ -584,7 +568,7 @@ def test_deprecated_objects(caplog, deprecated_allele):
         {"start": 2, "end": '2'}
     ]
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             SimpleInterval(**invalid_param)
 
     allele = Allele(**deprecated_allele)

--- a/tests/test_vrsatile_models.py
+++ b/tests/test_vrsatile_models.py
@@ -3,7 +3,7 @@ import pydantic
 import pytest
 
 from ga4gh.vrsatile.pydantic.vrs_models import Number, SequenceLocation, \
-    SequenceInterval, LiteralSequenceExpression, Allele, Sequence
+    SequenceInterval, LiteralSequenceExpression, Allele, SEQUENCE
 from ga4gh.vrsatile.pydantic.vrsatile_models import  \
     MoleculeContext, Extension, Expression, ValueObjectDescriptor, \
     SequenceDescriptor, LocationDescriptor, GeneDescriptor, \
@@ -101,7 +101,7 @@ def test_extension(extension):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Extension(**invalid_param)
 
 
@@ -130,7 +130,7 @@ def test_expression(expression):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             Expression(**invalid_param)
 
 
@@ -166,7 +166,7 @@ def test_value_object_descriptor(extension, expression):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             ValueObjectDescriptor(**invalid_param)
 
 
@@ -191,7 +191,7 @@ def test_sequence_descriptor(sequence_descriptor, gene):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             SequenceDescriptor(**invalid_param)
 
 
@@ -229,7 +229,7 @@ def test_location_descriptor(location_descriptor, sequence_location, gene):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             LocationDescriptor(**invalid_param)
 
 
@@ -254,7 +254,7 @@ def test_gene_descriptor(gene_descriptor, gene):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             GeneDescriptor(**invalid_param)
 
 
@@ -275,7 +275,7 @@ def test_vcf_record(vcf_record):
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             VCFRecord(**invalid_param)
 
 
@@ -340,7 +340,7 @@ def test_variation_descriptor(allele, gene_descriptor, vcf_record, expression,
     ]
 
     for invalid_param in invalid_params:
-        with pytest.raises(pydantic.error_wrappers.ValidationError):
+        with pytest.raises(pydantic.ValidationError):
             VariationDescriptor(**invalid_param)
 
 
@@ -361,11 +361,12 @@ def test_canonical_variation(allele):
     assert cv.variation.state.type.value == "LiteralSequenceExpression"
     assert cv.variation.state.sequence == "C"
 
-    assert set(cv.schema()["properties"].keys()) == {"_id", "type",
-                                                     "complement", "variation"}
+    assert set(cv.model_json_schema()["properties"].keys()) == {
+        "_id", "type", "complement", "variation"
+    }
 
     # check forbid extra
-    with pytest.raises(pydantic.error_wrappers.ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         CanonicalVariation(
             _id="clinvar:13961",
             complement=False,
@@ -396,7 +397,7 @@ def test_categorical_variation(allele):
                         )
                     ),
                     state=LiteralSequenceExpression(
-                        sequence=Sequence(__root__="T")
+                        sequence=SEQUENCE("T")
                     )
                 )
             )


### PR DESCRIPTION
close #69 

Notes:
- Upgrade to pydantic v2 
  - This is needed for ensuring cool-seq-tool can use both versions of gene-normalizer. 
-  I just removed work that was done in #19 . We won't be using this package once we only maintain VRS 2-alpha in VRS-Python. I don't know if it's important or not. I can add back if it is.